### PR TITLE
Fix deps when used as a library

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,9 +5,5 @@
     "semiColons": true,
     "singleQuote": true,
     "useTabs": false
-  },
-  "imports": {
-    "$std/": "https://deno.land/std@0.192.0/",
-    "zod": "https://deno.land/x/zod@v3.21.4/mod.ts"
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,2 @@
+export { deepMerge } from 'https://deno.land/std@0.192.0/collections/deep_merge.ts';
+export { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts';

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,0 +1,2 @@
+export { afterAll, beforeAll, describe, it } from 'https://deno.land/std@0.192.0/testing/bdd.ts';
+export { assertEquals, assertExists } from 'https://deno.land/std@0.192.0/testing/asserts.ts';

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -1,5 +1,4 @@
-import { afterAll, beforeAll, describe, it } from '$std/testing/bdd.ts';
-import { assertEquals, assertExists } from '$std/testing/asserts.ts';
+import { assertEquals, assertExists, afterAll, beforeAll, describe, it } from '../deps_test.ts';
 import { d, Dongoose } from '../mod.ts';
 
 const schema = {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,4 @@
-import { deepMerge } from '$std/collections/deep_merge.ts';
-import { z } from 'zod';
+import { deepMerge, z } from '../deps.ts';
 
 // Define the options for the Dongoose function
 interface DongooseOptions<T> {


### PR DESCRIPTION
When trying to use this library from deno.land, my application crashes on start with this error:

```
Watcher File change detected! Restarting!
error: Relative import path "zod" not prefixed with / or ./ or ../ and not in import map from "https://deno.land/x/dongoose@1.0.1/src/schema.ts"
    at https://deno.land/x/dongoose@1.0.1/src/schema.ts:2:19
Watcher Process finished. Restarting on file change...
```

This MR fixes it by creating a `deps.ts` and `deps_test.ts`. Deno can't use import maps for libraries since it doesn't know the URL of the import map. So when the project is a library it has to be this way.